### PR TITLE
Feature/keeps groups after reharvest

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -230,6 +230,7 @@ class DCATJSONHarvester(DCATHarvester):
             existing_dataset = self._get_existing_dataset(harvest_object.guid)
             if existing_dataset:
                 copy_across_resource_ids(existing_dataset, package_dict)
+                copy_across_resource_groups(existing_dataset, package_dict)
 
         # Allow custom harvesters to modify the package dict before creating
         # or updating the package
@@ -298,7 +299,7 @@ class DCATJSONHarvester(DCATHarvester):
 def copy_across_resource_ids(existing_dataset, harvested_dataset):
     '''Compare the resources in a dataset existing in the CKAN database with
     the resources in a freshly harvested copy, and for any resources that are
-    the same, copy the resource ID into the harvested_dataset dict.
+    the same, copy the resource ID and groups into the harvested_dataset dict.
     '''
     # take a copy of the existing_resources so we can remove them when they are
     # matched - we don't want to match them more than once.
@@ -343,3 +344,10 @@ def copy_across_resource_ids(existing_dataset, harvested_dataset):
                     matching_existing_resource)
         if not existing_resources_still_to_match:
             break
+
+
+def copy_across_resource_groups(existing_dataset, harvested_dataset):
+    existing_groups = existing_dataset.get('groups')
+
+    if existing_groups:
+        harvested_dataset['groups'] = existing_groups

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -299,7 +299,7 @@ class DCATJSONHarvester(DCATHarvester):
 def copy_across_resource_ids(existing_dataset, harvested_dataset):
     '''Compare the resources in a dataset existing in the CKAN database with
     the resources in a freshly harvested copy, and for any resources that are
-    the same, copy the resource ID and groups into the harvested_dataset dict.
+    the same, copy the resource ID into the harvested_dataset dict.
     '''
     # take a copy of the existing_resources so we can remove them when they are
     # matched - we don't want to match them more than once.

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -230,6 +230,7 @@ class DCATJSONHarvester(DCATHarvester):
             existing_dataset = self._get_existing_dataset(harvest_object.guid)
             if existing_dataset:
                 copy_across_resource_ids(existing_dataset, package_dict)
+                copy_across_dataset_groups(existing_dataset, package_dict)
 
         # Allow custom harvesters to modify the package dict before creating
         # or updating the package
@@ -343,3 +344,12 @@ def copy_across_resource_ids(existing_dataset, harvested_dataset):
                     matching_existing_resource)
         if not existing_resources_still_to_match:
             break
+
+
+def copy_across_dataset_groups(existing_dataset, harvested_dataset):
+    '''Copies the groups any existing datasets
+    are in to the newly harvested datasets'''
+    existing_groups = existing_dataset.get('groups')
+
+    if existing_groups:
+        harvested_dataset['groups'] = existing_groups

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -8,7 +8,9 @@ import ckantoolkit.tests.helpers as h
 
 import ckan.tests.factories as factories
 
-from ckanext.dcat.harvesters._json import copy_across_resource_ids, DCATJSONHarvester
+from ckanext.dcat.harvesters._json import (copy_across_resource_ids,
+                                           DCATJSONHarvester,
+                                           copy_across_dataset_groups)
 from test_harvester import FunctionalHarvestTest
 
 eq_ = nose.tools.eq_
@@ -323,3 +325,31 @@ class TestImportStage:
 
         assert 'Error importing dataset Invalid tags: ValidationError(None,)' in args[0]
         assert '{\'tags\': [{}, u\'Tag "test\\\'s" must be alphanumeric characters or symbols: -_.\', u\'Tag "invalid & wrong" must be alphanumeric characters or symbols: -_.\']}' in args[0]
+
+
+class TestCopyAcrossDatasetGroups:
+    def test_groups_copied(self):
+        harvested_dataset = {}
+        existing_dataset = {'groups': [{
+            'display_name': u'education',
+            u'description': u'',
+            u'title': u'education',
+            'image_display_url': u'',
+            u'id': u'ed944b74-6338-4cbd-83df-0927ff8ae8ab',
+            u'name': u'education'
+        }, {
+            'display_name': u'other',
+            u'description': u'',
+            u'title': u'other',
+            'image_display_url': u'',
+            u'id': u'95291d78-7c33-48e6-bd06-5751254e5bf7',
+            u'name': u'other'}]
+        }
+
+        copy_across_dataset_groups(
+            existing_dataset,
+            harvested_dataset,
+        )
+
+        eq_(harvested_dataset['groups'][0].get('name'),
+            existing_dataset['groups'][0].get('name'))


### PR DESCRIPTION
If you add a dataset to a group after harvesting, then you reharvest using DCAT json type, you lose the reference to that group. This copies the existing dataset groups to the newly harvested versions.